### PR TITLE
Added various options, https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,36 @@ It provides:
   * Only proxies images from the same domain that the proxy is running on - not an open proxy (this could be easily changed in future)
 
 
-## Installation
+## Installation & Configuration
 
     npm install connect-image-proxy
 
+You may have to install graphicsmagick too:
+
+    apt-get install graphicsmagick
+
 and then in your code (eg an Express app):
 
-    var image_proxy = require('connect-image-proxy');
+    var ImageProxy = require('connect-image-proxy');
 
     app.configure(function(){
       ....
 
+      var myproxy = new ImageProxy({
+        hostsWhitelist: ['mysite.com', 'images.mysite.com'],
+        headers: {'Cache-Control': 'max-age=31536000'},
+      });
+
       // mount the proxy at '/proxy'
-      app.use( '/proxy', image_proxy() );
+      app.use( '/proxy', myproxy.requestHandler );
       ....
     });
+
+### Configuration Options
+
+  * validMimeTypes: list of valid MIME types.  Defaults to ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'].
+  * hostsWhitelist: list of allowed hosts.  If not set, defaults to serving requests only for images on the same host as this server.
+  * headers: map of http headers to their values.  Note that Content-Type is always set to the appropriate MIME type.
 
 
 ## Usage
@@ -42,5 +57,5 @@ There is an example app in the `examples` folder that demonstrates the basic fea
 
 ## TODO
 
-  * Allow user to specify a list of hostnames to proxy for, not just the same host as the proxy is running on.
-  * Add proper caching headers, or at least repeat the cache headers of the original image.
+  * https support
+  * pass along headers by default?

--- a/README.md
+++ b/README.md
@@ -57,5 +57,4 @@ There is an example app in the `examples` folder that demonstrates the basic fea
 
 ## TODO
 
-  * https support
   * pass along headers by default?

--- a/examples/app.js
+++ b/examples/app.js
@@ -1,4 +1,4 @@
-var image_proxy = require('..');
+var ImageProxy = require('..');
 
 var express = require('express');
 var app = express.createServer();
@@ -13,7 +13,11 @@ app.configure(function(){
   app.use("/images", express.static(__dirname + '/public'));
 
   // Use the proxy
-  app.use('/proxy', image_proxy() );
+  var myproxy = new ImageProxy({
+    hostsWhitelist: ['www.google.com', 'localhost:3000'],
+    headers: {'Cache-Control': 'max-age=31536000'},
+  });
+  app.use('/proxy', myproxy.requestHandler);
 
   app.use(app.router);
   app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));

--- a/lib/image-proxy.js
+++ b/lib/image-proxy.js
@@ -8,22 +8,49 @@ var
     temp          = require('temp');
     // request       = require('request');
 
-var validMimeTypes = {
-  'image/jpeg': true,
-  'image/png':  true,
-  'image/gif':  true,
-  'image/jpg':  true,
-};
 
-module.exports = function () {
-  return function image_proxy (req, res, next){
-    
+function ImageProxy(opts) {
+
+  var validMimeTypes = {
+    'image/jpeg': true,
+    'image/png':  true,
+    'image/gif':  true,
+    'image/jpg':  true,
+  };
+
+  var headers = {};
+
+  var restrictToLocal = true;
+  var hostsWhitelist = {};
+
+  if (opts.headers) {
+    headers = opts.headers;
+  }
+
+  if (opts.validMimeTypes) {
+    validMimeTypes = listToObj(opts.validMimeTypes);
+  }
+
+  if (opts.hostsWhitelist) {
+    restrictToLocal = false;
+    hostsWhitelist = listToObj(opts.hostsWhitelist);
+  }
+
+  function listToObj(list) {
+    var ret = {};
+    for (var i=0; i < list.length; i++) {
+      ret[list[i]] = true;
+    }
+    return ret;
+  }
+
+  this.requestHandler = function(req, res, next) {
     // get the remote url. If none given abort request
     var remoteUrl = req.param('url');
     if (! remoteUrl) {
-      return res.send("No 'url' parameter specified, can't proxy", 404);
+      return res.send("No 'url' parameter specified, can't proxy", 500);
     }
-    
+
     // Turn paths into full urls. Assume that the host and port should be the
     // same as the request's, and the protocol 'http'.
     var urlObject = url.parse(remoteUrl);
@@ -34,34 +61,42 @@ module.exports = function () {
       urlObject.port     = hostFromHeader.port;
       urlObject.protocol = hostFromHeader.protocol;
     }
-    
+
     // In future perhaps allow user to provide a whitelist of hosts to proxy for
-    if( urlObject.host != req.headers.host ) {
-      return res.send(
-        "Will only proxy requests to " + req.headers.host + ", not " + urlObject.host,
-        404
-      );
+    if (restrictToLocal) {
+      if( urlObject.host != req.headers.host ) {
+        return res.send(
+          "Will only proxy requests to " + req.headers.host + ", not " + urlObject.host,
+          500
+        );
+      }
+    }
+    else if (!(urlObject.host in hostsWhitelist)) {
+        return res.send(
+          "Invalid host.",
+          500
+        );
     }
 
     var handleImageResponse = function (imageResponse) {
-    
+
       // check that the response is acceptable. Should be a 200.
       if ( imageResponse.statusCode != 200 ) {
-        res.send('url ' + remoteUrl + ' did not return 200', 404);
+        res.send('url ' + remoteUrl + ' did not return 200', 500);
         return;
       }
-      
+
       // get the mime type from the response, check it is accetpable
       var mimeType = imageResponse.headers['content-type'];
       if ( ! validMimeTypes[mimeType] ) {
-        res.send('Can not handle mime type ' + mimeType, 404);
-        return;          
+        res.send('Can not handle mime type ' + mimeType, 500);
+        return;
       }
-    
+
       var fileExt       = mime.extension( mimeType );
       var tempImageFile = temp.path({suffix: '.'+fileExt});
       var writeStream   = fs.createWriteStream(tempImageFile);
-    
+
       imageResponse
         .on('data', function (chunk) {
           writeStream.write(chunk);
@@ -70,54 +105,59 @@ module.exports = function () {
           writeStream.end(function() {
 
             var image = gm( tempImageFile );
-                
+
             if( req.param('resize') ) {
               var newWidth  = req.param('width')  || '';
               var newHeight = req.param('height') || '';
-                
+
               if( !newHeight && !newWidth) {
-                res.send('need one of height and/or width to resize', 404);
-                return;          
-              }                
+                res.send('need one of height and/or width to resize', 500);
+                return;
+              }
 
               image = image.resize(newWidth + 'x' + newHeight);
             }
-                
+
             if ( req.param('grayscale')) {
               image = image.type('grayscale');
             }
-                
+
             if ( req.param('format') ) {
               image    = image.setFormat( req.param('format') );
-              mimeType = req.param('format');      
+              mimeType = req.param('format');
             }
-                
+
             // all done - render the image
             image.stream( function (err, stdout, stderr) {
-              if (err) return next(err);
+              if (err) {
+                console.error(err);
+                return next(err);
+              }
               stderr.pipe(process.stderr);
-                
-              res.writeHead( 200, {"Content-Type": mimeType});
+
+              headers['Content-Type'] = mimeType;
+              res.writeHead(200, headers);
 
               // pipe the output straight to the response.
               stdout.pipe(res);
-              
+
               // at the end delete the temporary file.
               stdout.on("end", function() {
                 fs.unlink(tempImageFile);
               });
 
             });
-
           });
         });
-    
+
     };
-    
+
     // request the remote url
     http
       .get(urlObject, handleImageResponse)
       .on('error', next );
 
-  };
-};
+  }
+}
+
+module.exports = ImageProxy;

--- a/lib/image-proxy.js
+++ b/lib/image-proxy.js
@@ -4,6 +4,7 @@ var
     mime          = require('mime'),
     url           = require('url'),
     http          = require('http'),
+    https          = require('https'),
     gm            = require('gm'),
     temp          = require('temp');
     // request       = require('request');
@@ -153,10 +154,10 @@ function ImageProxy(opts) {
     };
 
     // request the remote url
-    http
+    var client = urlObject.protocol === 'https:' ? https : http;
+    client
       .get(urlObject, handleImageResponse)
       .on('error', next );
-
   }
 }
 


### PR DESCRIPTION
I refactored things into an ImageProxy class that you can use like so:

```
  var myproxy = new ImageProxy({
    validMimeTypes: ['image/png'],
    hostsWhitelist: ['mysite.com', 'images.mysite.com'],
    headers: {'Cache-Control': 'max-age=31536000'},
  });

  // mount the proxy at '/proxy'
  app.use( '/proxy', myproxy.requestHandler );
```

We accept the following options:
- validMimeTypes - defaults to jpg/jpeg, png, gif
- hostsWhitelist - defaults to the same host only
- headers - default to no additional headers besides content-type

I also added support for proxying images over https.

I realize that these changes are not backwards compatible so I understand if you'd prefer to keep things the old way.  I needed these features, so I went ahead and built them anyway.  Thank you for starting this project!
